### PR TITLE
Update to latest rspec version and syntax.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,21 +3,26 @@ GEM
   specs:
     codeclimate-test-reporter (0.3.0)
       simplecov (>= 0.7.1, < 1.0.0)
-    diff-lcs (1.2.3)
+    diff-lcs (1.2.5)
     docile (1.1.3)
     multi_json (1.9.0)
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
     rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.3)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -39,3 +44,6 @@ DEPENDENCIES
   rake
   rspec
   sinatra
+
+BUNDLED WITH
+   1.11.2

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -5,90 +5,88 @@ describe Rack::Test::Session do
   context "cookies" do
     it "keeps a cookie jar" do
       get "/cookies/show"
-      check last_request.cookies.should == {}
+      check expect(last_request.cookies).to eq({})
 
       get "/cookies/set", "value" => "1"
       get "/cookies/show"
-      last_request.cookies.should == { "value" => "1" }
+      expect(last_request.cookies).to eq({ "value" => "1" })
     end
 
     it "doesn't send expired cookies" do
       get "/cookies/set", "value" => "1"
       now = Time.now
-      Time.stub!(:now => now + 60)
+      allow(Time).to receive_messages(:now => now + 60)
       get "/cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "cookie path defaults to the uri of the document that was requested" do
-      pending "See issue rack-test github issue #50" do
-        post "/cookies/default-path", "value" => "cookie"
-        get "/cookies/default-path"
-        check last_request.cookies.should == { "simple"=>"cookie" }
-        get "/cookies/show"
-        check last_request.cookies.should == { }
-      end
+      skip "See issue rack-test github issue #50"
+      post "/cookies/default-path", "value" => "cookie"
+      get "/cookies/default-path"
+      expect(last_request.cookies).to eq({ "simple"=>"cookie" })
+      get "/cookies/show"
+      expect(last_request.cookies).to eq({})
     end
 
     it "escapes cookie values" do
       jar = Rack::Test::CookieJar.new
       jar["value"] = "foo;abc"
-      jar["value"].should == "foo;abc"
+      expect(jar["value"]).to eq("foo;abc")
     end
 
     it "deletes cookies directly from the CookieJar" do
       jar = Rack::Test::CookieJar.new
       jar["abcd"] = "1234"
-      jar["abcd"].should == "1234"
+      expect(jar["abcd"]).to eq("1234")
       jar.delete("abcd")
-      jar["abcd"].should == nil
+      expect(jar["abcd"]).to eq(nil)
     end
 
     it "doesn't send cookies with the wrong domain" do
       get "http://www.example.com/cookies/set", "value" => "1"
       get "http://www.other.example/cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "doesn't send cookies with the wrong path" do
       get "/cookies/set", "value" => "1"
       get "/not-cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "persists cookies across requests that don't return any cookie headers" do
       get "/cookies/set", "value" => "1"
       get "/void"
       get "/cookies/show"
-      last_request.cookies.should == { "value" => "1" }
+      expect(last_request.cookies).to eq({ "value" => "1" })
     end
 
     it "deletes cookies" do
       get "/cookies/set", "value" => "1"
       get "/cookies/delete"
       get "/cookies/show"
-      last_request.cookies.should == { }
+      expect(last_request.cookies).to eq({ })
     end
 
     it "respects cookie domains when no domain is explicitly set" do
-      pending "FIXME: www.example.org should not get the first cookie" do
-        request("http://example.org/cookies/count").should     have_body("1")
-        request("http://www.example.org/cookies/count").should have_body("1")
-        request("http://example.org/cookies/count").should     have_body("2")
-        request("http://www.example.org/cookies/count").should have_body("2")
-      end
+      skip "FIXME: www.example.org should not get the first cookie"
+      expect(request("http://example.org/cookies/count")).to     have_body("1")
+      expect(request("http://www.example.org/cookies/count")).to have_body("1")
+      expect(request("http://example.org/cookies/count")).to     have_body("2")
+      expect(request("http://www.example.org/cookies/count")).to have_body("2")
     end
 
     it "treats domains case insensitively" do
       get "http://example.com/cookies/set", "value" => "1"
       get "http://EXAMPLE.COM/cookies/show"
-      last_request.cookies.should == { "value" => "1" }
+      expect(last_request.cookies).to eq({ "value" => "1" })
     end
 
     it "treats paths case sensitively" do
       get "/cookies/set", "value" => "1"
       get "/COOKIES/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "prefers more specific cookies" do
@@ -96,124 +94,124 @@ describe Rack::Test::Session do
       get "http://sub.example.com/cookies/set", "value" => "sub"
 
       get "http://sub.example.com/cookies/show"
-      check last_request.cookies.should == { "value" => "sub" }
+      check expect(last_request.cookies).to eq({ "value" => "sub" })
 
       get "http://example.com/cookies/show"
-      last_request.cookies.should == { "value" => "domain" }
+      expect(last_request.cookies).to eq({ "value" => "domain" })
     end
 
     it "treats cookie names case insensitively" do
       get "/cookies/set", "value" => "lowercase"
       get "/cookies/set-uppercase", "value" => "UPPERCASE"
       get "/cookies/show"
-      last_request.cookies.should == { "VALUE" => "UPPERCASE" }
+      expect(last_request.cookies).to eq({ "VALUE" => "UPPERCASE" })
     end
 
     it "defaults the domain to the request domain" do
       get "http://example.com/cookies/set-simple", "value" => "cookie"
       get "http://example.com/cookies/show"
-      check last_request.cookies.should == { "simple" => "cookie" }
+      check expect(last_request.cookies).to eq({ "simple" => "cookie" })
 
       get "http://other.example/cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "defaults the domain to the request path up to the last slash" do
       get "/cookies/set-simple", "value" => "1"
       get "/not-cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "supports secure cookies" do
       get "https://example.com/cookies/set-secure", "value" => "set"
       get "http://example.com/cookies/show"
-      check last_request.cookies.should == {}
+      check expect(last_request.cookies).to eq({})
 
       get "https://example.com/cookies/show"
-      last_request.cookies.should == { "secure-cookie" => "set" }
-      rack_mock_session.cookie_jar['secure-cookie'].should == 'set'
+      expect(last_request.cookies).to eq({ "secure-cookie" => "set" })
+      expect(rack_mock_session.cookie_jar['secure-cookie']).to eq('set')
     end
 
     it "keeps separate cookie jars for different domains" do
       get "http://example.com/cookies/set", "value" => "example"
       get "http://example.com/cookies/show"
-      check last_request.cookies.should == { "value" => "example" }
+      check expect(last_request.cookies).to eq({ "value" => "example" })
 
       get "http://other.example/cookies/set", "value" => "other"
       get "http://other.example/cookies/show"
-      check last_request.cookies.should == { "value" => "other" }
+      check expect(last_request.cookies).to eq({ "value" => "other" })
 
       get "http://example.com/cookies/show"
-      last_request.cookies.should == { "value" => "example" }
+      expect(last_request.cookies).to eq({ "value" => "example" })
     end
 
     it "keeps one cookie jar for domain and its subdomains" do
       get "http://example.org/cookies/subdomain"
       get "http://example.org/cookies/subdomain"
-      last_request.cookies.should == { "count" => "1" }
+      expect(last_request.cookies).to eq({ "count" => "1" })
 
       get "http://foo.example.org/cookies/subdomain"
-      last_request.cookies.should == { "count" => "2" }
+      expect(last_request.cookies).to eq({ "count" => "2" })
     end
 
     it "allows cookies to be cleared" do
       get "/cookies/set", "value" => "1"
       clear_cookies
       get "/cookies/show"
-      last_request.cookies.should == {}
+      expect(last_request.cookies).to eq({})
     end
 
     it "allow cookies to be set" do
       set_cookie "value=10"
       get "/cookies/show"
-      last_request.cookies.should == { "value" => "10" }
+      expect(last_request.cookies).to eq({ "value" => "10" })
     end
 
     it "allows an array of cookies to be set" do
       set_cookie ["value=10", "foo=bar"]
       get "/cookies/show"
-      last_request.cookies.should == { "value" => "10", "foo" => "bar" }
+      expect(last_request.cookies).to eq({ "value" => "10", "foo" => "bar" })
     end
 
     it "skips emtpy string cookies" do
       set_cookie "value=10\n\nfoo=bar"
       get "/cookies/show"
-      last_request.cookies.should == { "value" => "10", "foo" => "bar" }
+      expect(last_request.cookies).to eq({ "value" => "10", "foo" => "bar" })
     end
 
     it "parses multiple cookies properly" do
       get "/cookies/set-multiple"
       get "/cookies/show"
-      last_request.cookies.should == { "key1" => "value1", "key2" => "value2" }
+      expect(last_request.cookies).to eq({ "key1" => "value1", "key2" => "value2" })
     end
 
     it "supports multiple sessions" do
       with_session(:first) do
         get "/cookies/set", "value" => "1"
         get "/cookies/show"
-        last_request.cookies.should == { "value" => "1" }
+        expect(last_request.cookies).to eq({ "value" => "1" })
       end
 
       with_session(:second) do
         get "/cookies/show"
-        last_request.cookies.should == { }
+        expect(last_request.cookies).to eq({ })
       end
     end
 
     it "uses :default as the default session name" do
       get "/cookies/set", "value" => "1"
       get "/cookies/show"
-      check last_request.cookies.should == { "value" => "1" }
+      check expect(last_request.cookies).to eq({ "value" => "1" })
 
       with_session(:default) do
         get "/cookies/show"
-        last_request.cookies.should == { "value" => "1" }
+        expect(last_request.cookies).to eq({ "value" => "1" })
       end
     end
 
     it "accepts explicitly provided cookies" do
       request "/cookies/show", :cookie => "value=1"
-      last_request.cookies.should == { "value" => "1" }
+      expect(last_request.cookies).to eq({ "value" => "1" })
     end
   end
 end

--- a/spec/rack/test/digest_auth_spec.rb
+++ b/spec/rack/test/digest_auth_spec.rb
@@ -15,31 +15,31 @@ describe Rack::Test::Session do
     it 'incorrectly authenticates GETs' do
       digest_authorize 'foo', 'bar'
       get '/'
-      last_response.should be_challenge
+      expect(last_response).to be_challenge
     end
 
     it "correctly authenticates GETs" do
       digest_authorize "alice", "correct-password"
       response = get "/"
-      response.should be_ok
+      expect(response).to be_ok
     end
 
     it "correctly authenticates GETs with params" do
       digest_authorize "alice", "correct-password"
       response = get "/", "foo" => "bar"
-      response.should be_ok
+      expect(response).to be_ok
     end
 
     it "correctly authenticates POSTs" do
       digest_authorize "alice", "correct-password"
       response = post "/"
-      response.should be_ok
+      expect(response).to be_ok
     end
 
     it "returns a re-challenge if authenticating incorrectly" do
       digest_authorize "alice", "incorrect-password"
       response = get "/"
-      response.should be_challenge
+      expect(response).to be_challenge
     end
 
   end

--- a/spec/rack/test/multipart_spec.rb
+++ b/spec/rack/test/multipart_spec.rb
@@ -23,83 +23,83 @@ describe Rack::Test::Session do
   context "uploading a file" do
     it "sends the multipart/form-data content type" do
       post "/", "photo" => uploaded_file
-      last_request.env["CONTENT_TYPE"].should include("multipart/form-data;")
+      expect(last_request.env["CONTENT_TYPE"]).to include("multipart/form-data;")
     end
 
     it "sends regular params" do
       post "/", "photo" => uploaded_file, "foo" => "bar"
-      last_request.POST["foo"].should == "bar"
+      expect(last_request.POST["foo"]).to eq("bar")
     end
 
     it "sends nested params" do
       post "/", "photo" => uploaded_file, "foo" => {"bar" => "baz"}
-      last_request.POST["foo"]["bar"].should == "baz"
+      expect(last_request.POST["foo"]["bar"]).to eq("baz")
     end
 
     it "sends multiple nested params" do
       post "/", "photo" => uploaded_file, "foo" => {"bar" => {"baz" => "bop"}}
-      last_request.POST["foo"]["bar"]["baz"].should == "bop"
+      expect(last_request.POST["foo"]["bar"]["baz"]).to eq("bop")
     end
 
     it "sends params with arrays" do
       post "/", "photo" => uploaded_file, "foo" => ["1", "2"]
-      last_request.POST["foo"].should == ["1", "2"]
+      expect(last_request.POST["foo"]).to eq(["1", "2"])
     end
 
     it "sends params with encoding sensitive values" do
       post "/", "photo" => uploaded_file, "foo" => "bar? baz"
-      last_request.POST["foo"].should == "bar? baz"
+      expect(last_request.POST["foo"]).to eq("bar? baz")
     end
 
     it "sends params encoded as ISO-8859-1" do
       post "/", "photo" => uploaded_file, "foo" => "bar", "utf8" => "☃"
-      last_request.POST["foo"].should == "bar"
+      expect(last_request.POST["foo"]).to eq("bar")
 
       if Rack::Test.encoding_aware_strings?
-        last_request.POST["utf8"].should == "☃"
+        expect(last_request.POST["utf8"]).to eq("☃")
       else
-        last_request.POST["utf8"].should == "\xE2\x98\x83"
+        expect(last_request.POST["utf8"]).to eq("\xE2\x98\x83")
       end
     end
 
     it "sends params with parens in names" do
       post "/", "photo" => uploaded_file, "foo(1i)" => "bar"
-      last_request.POST["foo(1i)"].should == "bar"
+      expect(last_request.POST["foo(1i)"]).to eq("bar")
     end
 
     it "sends params with encoding sensitive names" do
       post "/", "photo" => uploaded_file, "foo bar" => "baz"
-      last_request.POST["foo bar"].should == "baz"
+      expect(last_request.POST["foo bar"]).to eq("baz")
     end
 
     it "sends files with the filename" do
       post "/", "photo" => uploaded_file
-      last_request.POST["photo"][:filename].should == "foo.txt"
+      expect(last_request.POST["photo"][:filename]).to eq("foo.txt")
     end
 
     it "sends files with the text/plain MIME type by default" do
       post "/", "photo" => uploaded_file
-      last_request.POST["photo"][:type].should == "text/plain"
+      expect(last_request.POST["photo"][:type]).to eq("text/plain")
     end
 
     it "sends files with the right name" do
       post "/", "photo" => uploaded_file
-      last_request.POST["photo"][:name].should == "photo"
+      expect(last_request.POST["photo"][:name]).to eq("photo")
     end
 
     it "allows overriding the content type" do
       post "/", "photo" => Rack::Test::UploadedFile.new(test_file_path, "image/jpeg")
-      last_request.POST["photo"][:type].should == "image/jpeg"
+      expect(last_request.POST["photo"][:type]).to eq("image/jpeg")
     end
 
     it "sends files with a Content-Length in the header" do
       post "/", "photo" => uploaded_file
-      last_request.POST["photo"][:head].should include("Content-Length: 4")
+      expect(last_request.POST["photo"][:head]).to include("Content-Length: 4")
     end
 
     it "sends files as Tempfiles" do
       post "/", "photo" => uploaded_file
-      last_request.POST["photo"][:tempfile].should be_a(::Tempfile)
+      expect(last_request.POST["photo"][:tempfile]).to be_a(::Tempfile)
     end
   end
 
@@ -107,39 +107,39 @@ describe Rack::Test::Session do
   context "uploading two files" do
     it "sends the multipart/form-data content type" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.env["CONTENT_TYPE"].should include("multipart/form-data;")
+      expect(last_request.env["CONTENT_TYPE"]).to include("multipart/form-data;")
     end
 
     it "sends files with the filename" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.POST["photos"].collect{|photo| photo[:filename]}.should == ["foo.txt", "bar.txt"]
+      expect(last_request.POST["photos"].collect{|photo| photo[:filename]}).to eq(["foo.txt", "bar.txt"])
     end
 
     it "sends files with the text/plain MIME type by default" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.POST["photos"].collect{|photo| photo[:type]}.should == ["text/plain", "text/plain"]
+      expect(last_request.POST["photos"].collect{|photo| photo[:type]}).to eq(["text/plain", "text/plain"])
     end
 
     it "sends files with the right names" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.POST["photos"].all?{|photo| photo[:name].should == "photos[]" }
+      last_request.POST["photos"].all?{|photo| expect(photo[:name]).to eq("photos[]") }
     end
 
     it "allows mixed content types" do
       image_file = Rack::Test::UploadedFile.new(test_file_path, "image/jpeg")
 
       post "/", "photos" => [uploaded_file, image_file]
-      last_request.POST["photos"].collect{|photo| photo[:type]}.should == ["text/plain", "image/jpeg"]
+      expect(last_request.POST["photos"].collect{|photo| photo[:type]}).to eq(["text/plain", "image/jpeg"])
     end
 
     it "sends files with a Content-Length in the header" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.POST["photos"].all?{|photo| photo[:head].should include("Content-Length: 4") }
+      last_request.POST["photos"].all?{|photo| expect(photo[:head]).to include("Content-Length: 4") }
     end
 
     it "sends both files as Tempfiles" do
       post "/", "photos" => [uploaded_file, second_uploaded_file]
-      last_request.POST["photos"].all?{|photo| photo[:tempfile].should be_a(::Tempfile) }
+      last_request.POST["photos"].all?{|photo| expect(photo[:tempfile]).to be_a(::Tempfile) }
     end
   end
 end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -8,22 +8,22 @@ describe Rack::Test::UploadedFile do
   it "responds to things that Tempfile responds to" do
     uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
-    uploaded_file.should respond_to(:close)
-    uploaded_file.should respond_to(:close!)
-    uploaded_file.should respond_to(:delete)
-    uploaded_file.should respond_to(:length)
-    uploaded_file.should respond_to(:open)
-    uploaded_file.should respond_to(:path)
-    uploaded_file.should respond_to(:size)
-    uploaded_file.should respond_to(:unlink)
-    uploaded_file.should respond_to(:read)
-    uploaded_file.should respond_to(:original_filename)
-    uploaded_file.should respond_to(:tempfile) # Allows calls to params[:file].tempfile
+    expect(uploaded_file).to respond_to(:close)
+    expect(uploaded_file).to respond_to(:close!)
+    expect(uploaded_file).to respond_to(:delete)
+    expect(uploaded_file).to respond_to(:length)
+    expect(uploaded_file).to respond_to(:open)
+    expect(uploaded_file).to respond_to(:path)
+    expect(uploaded_file).to respond_to(:size)
+    expect(uploaded_file).to respond_to(:unlink)
+    expect(uploaded_file).to respond_to(:read)
+    expect(uploaded_file).to respond_to(:original_filename)
+    expect(uploaded_file).to respond_to(:tempfile) # Allows calls to params[:file].tempfile
   end
 
   it "creates Tempfiles with original file's extension" do
     uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
-    File.extname(uploaded_file.path).should eq(".txt")
+    expect(File.extname(uploaded_file.path)).to eq(".txt")
   end
 end

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -5,48 +5,48 @@ describe Rack::Test::Utils do
 
   describe "build_nested_query" do
     it "converts empty strings to =" do
-      build_nested_query("").should == "="
+      expect(build_nested_query("")).to eq("=")
     end
 
     it "converts nil to an empty string" do
-      build_nested_query(nil).should == ""
+      expect(build_nested_query(nil)).to eq("")
     end
 
     it "converts hashes with nil values" do
-      build_nested_query(:a => nil).should == "a"
+      expect(build_nested_query(:a => nil)).to eq("a")
     end
 
     it "converts hashes" do
-      build_nested_query(:a => 1).should == "a=1"
+      expect(build_nested_query(:a => 1)).to eq("a=1")
     end
 
     it "converts hashes with multiple keys" do
       hash = { :a => 1, :b => 2 }
-      ["a=1&b=2", "b=2&a=1"].should include(build_nested_query(hash))
+      expect(["a=1&b=2", "b=2&a=1"]).to include(build_nested_query(hash))
     end
 
     it "converts arrays with one element" do
-      build_nested_query(:a => [1]).should == "a[]=1"
+      expect(build_nested_query(:a => [1])).to eq("a[]=1")
     end
 
     it "converts arrays with multiple elements" do
-      build_nested_query(:a => [1, 2]).should == "a[]=1&a[]=2"
+      expect(build_nested_query(:a => [1, 2])).to eq("a[]=1&a[]=2")
     end
 
     it "converts arrays with brackets '[]' in the name" do
-      build_nested_query("a[]" => [1, 2]).should == "a%5B%5D=1&a%5B%5D=2"
+      expect(build_nested_query("a[]" => [1, 2])).to eq("a%5B%5D=1&a%5B%5D=2")
     end
 
     it "converts nested hashes" do
-      build_nested_query(:a => { :b => 1 }).should == "a[b]=1"
+      expect(build_nested_query(:a => { :b => 1 })).to eq("a[b]=1")
     end
 
     it "converts arrays nested in a hash" do
-      build_nested_query(:a => { :b => [1, 2] }).should == "a[b][]=1&a[b][]=2"
+      expect(build_nested_query(:a => { :b => [1, 2] })).to eq("a[b][]=1&a[b][]=2")
     end
 
     it "converts arrays of hashes" do
-      build_nested_query(:a => [{ :b => 2}, { :c => 3}]).should == "a[][b]=2&a[][c]=3"
+      expect(build_nested_query(:a => [{ :b => 2}, { :c => 3}])).to eq("a[][b]=2&a[][c]=3")
     end
   end
 
@@ -62,9 +62,9 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["submit-name"].should == "Larry"
-      check params["files"][:filename].should == "foo.txt"
-      params["files"][:tempfile].read.should == "bar\n"
+      check expect(params["submit-name"]).to eq("Larry")
+      check expect(params["files"][:filename]).to eq("foo.txt")
+      expect(params["files"][:tempfile].read).to eq("bar\n")
     end
 
    it "builds multipart bodies from array of files" do
@@ -78,13 +78,13 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["submit-name"].should == "Larry"
+      check expect(params["submit-name"]).to eq("Larry")
 
-      check params["files"][0][:filename].should == "foo.txt"
-      params["files"][0][:tempfile].read.should == "bar\n"
+      check expect(params["files"][0][:filename]).to eq("foo.txt")
+      expect(params["files"][0][:tempfile].read).to eq("bar\n")
 
-      check params["files"][1][:filename].should == "bar.txt"
-      params["files"][1][:tempfile].read.should == "baz\n"
+      check expect(params["files"][1][:filename]).to eq("bar.txt")
+      expect(params["files"][1][:tempfile].read).to eq("baz\n")
     end
 
     it "builds nested multipart bodies" do
@@ -98,10 +98,10 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["people"][0]["submit-name"].should == "Larry"
-      check params["people"][0]["files"][:filename].should == "foo.txt"
-      params["people"][0]["files"][:tempfile].read.should == "bar\n"
-      check params["foo"].should == ["1", "2"]
+      check expect(params["people"][0]["submit-name"]).to eq("Larry")
+      check expect(params["people"][0]["files"][:filename]).to eq("foo.txt")
+      expect(params["people"][0]["files"][:tempfile].read).to eq("bar\n")
+      check expect(params["foo"]).to eq(["1", "2"])
     end
 
     it "builds nested multipart bodies with an array of hashes" do
@@ -115,9 +115,9 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["files"][:filename].should == "foo.txt"
-      params["files"][:tempfile].read.should == "bar\n"
-      check params["foo"].should == [{"id" => "1", "name" => "Dave"}, {"id" => "2", "name" => "Steve"}]
+      check expect(params["files"][:filename]).to eq("foo.txt")
+      expect(params["files"][:tempfile].read).to eq("bar\n")
+      check expect(params["foo"]).to eq([{"id" => "1", "name" => "Dave"}, {"id" => "2", "name" => "Steve"}])
     end
 
     it "builds nested multipart bodies with arbitrarily nested array of hashes" do
@@ -133,11 +133,11 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["files"][:filename].should == "foo.txt"
-      params["files"][:tempfile].read.should == "bar\n"
-      check params["foo"].should == {"bar" => [{"id" => "1", "name" => "Dave"},
+      check expect(params["files"][:filename]).to eq("foo.txt")
+      expect(params["files"][:tempfile].read).to eq("bar\n")
+      check expect(params["foo"]).to eq({"bar" => [{"id" => "1", "name" => "Dave"},
                                                {"id" => "2", "name" => "Steve", "qux" => [{"id" => '3', "name" => 'mike'},
-                                                                                          {"id" => '4', "name" => 'Joan'}]}]}
+                                                                                          {"id" => '4', "name" => 'Joan'}]}]})
     end
 
     it 'does not break with params that look nested, but are not' do
@@ -151,10 +151,10 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["files"][0][:filename].should == "foo.txt"
-      params["files"][0][:tempfile].read.should == "bar\n"
-      check params["foo"][0].should == "1"
-      check params["bar"][0].should == {"qux" => "2"}
+      check expect(params["files"][0][:filename]).to eq("foo.txt")
+      expect(params["files"][0][:tempfile].read).to eq("bar\n")
+      check expect(params["foo"][0]).to eq("1")
+      check expect(params["bar"][0]).to eq({"qux" => "2"})
     end
 
     it 'allows for nested files' do
@@ -169,21 +169,21 @@ describe Rack::Test::Utils do
       }
       env = Rack::MockRequest.env_for("/", options)
       params = Rack::Utils::Multipart.parse_multipart(env)
-      check params["foo"][0]["id"].should == "1"
-      check params["foo"][0]["data"][:filename].should == "foo.txt"
-      params["foo"][0]["data"][:tempfile].read.should == "bar\n"
-      check params["foo"][1].should == {"id" => "2", "data" => ["3", "4"]}
+      check expect(params["foo"][0]["id"]).to eq("1")
+      check expect(params["foo"][0]["data"][:filename]).to eq("foo.txt")
+      expect(params["foo"][0]["data"][:tempfile].read).to eq("bar\n")
+      check expect(params["foo"][1]).to eq({"id" => "2", "data" => ["3", "4"]})
     end
 
     it "returns nil if no UploadedFiles were used" do
       data = build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
-      data.should be_nil
+      expect(data).to be_nil
     end
 
     it "raises ArgumentErrors if params is not a Hash" do
-      lambda {
+      expect {
         build_multipart("foo=bar")
-      }.should raise_error(ArgumentError, "value must be a Hash")
+      }.to raise_error(ArgumentError, "value must be a Hash")
     end
 
     def multipart_file(name)

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -4,142 +4,142 @@ describe Rack::Test::Session do
   describe "initialization" do
     it "supports being initialized with a Rack::MockSession app" do
       session = Rack::Test::Session.new(Rack::MockSession.new(app))
-      session.request("/").should be_ok
+      expect(session.request("/")).to be_ok
     end
 
     it "supports being initialized with an app" do
       session = Rack::Test::Session.new(app)
-      session.request("/").should be_ok
+      expect(session.request("/")).to be_ok
     end
   end
 
   describe "#request" do
     it "requests the URI using GET by default" do
       request "/"
-      last_request.should be_get
-      last_response.should be_ok
+      expect(last_request).to be_get
+      expect(last_response).to be_ok
     end
 
     it "returns a response" do
-      request("/").should be_ok
+      expect(request("/")).to be_ok
     end
 
     it "uses the provided env" do
       request "/", "X-Foo" => "bar"
-      last_request.env["X-Foo"].should == "bar"
+      expect(last_request.env["X-Foo"]).to eq("bar")
     end
 
     it "allows HTTP_HOST to be set" do
       request "/", "HTTP_HOST" => "www.example.ua"
-      last_request.env['HTTP_HOST'].should == "www.example.ua"
+      expect(last_request.env['HTTP_HOST']).to eq("www.example.ua")
     end
 
     it "sets HTTP_HOST with port for non-default ports" do
       request "http://foo.com:8080"
-      last_request.env["HTTP_HOST"].should == "foo.com:8080"
+      expect(last_request.env["HTTP_HOST"]).to eq("foo.com:8080")
       request "https://foo.com:8443"
-      last_request.env["HTTP_HOST"].should == "foo.com:8443"
+      expect(last_request.env["HTTP_HOST"]).to eq("foo.com:8443")
     end
 
     it "sets HTTP_HOST without port for default ports" do
       request "http://foo.com"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      expect(last_request.env["HTTP_HOST"]).to eq("foo.com")
       request "http://foo.com:80"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      expect(last_request.env["HTTP_HOST"]).to eq("foo.com")
       request "https://foo.com:443"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      expect(last_request.env["HTTP_HOST"]).to eq("foo.com")
     end
 
     it "defaults to GET" do
       request "/"
-      last_request.env["REQUEST_METHOD"].should == "GET"
+      expect(last_request.env["REQUEST_METHOD"]).to eq("GET")
     end
 
     it "defaults the REMOTE_ADDR to 127.0.0.1" do
       request "/"
-      last_request.env["REMOTE_ADDR"].should == "127.0.0.1"
+      expect(last_request.env["REMOTE_ADDR"]).to eq("127.0.0.1")
     end
 
     it "sets rack.test to true in the env" do
       request "/"
-      last_request.env["rack.test"].should == true
+      expect(last_request.env["rack.test"]).to eq(true)
     end
 
     it "defaults to port 80" do
       request "/"
-      last_request.env["SERVER_PORT"].should == "80"
+      expect(last_request.env["SERVER_PORT"]).to eq("80")
     end
 
     it "defaults to example.org" do
       request "/"
-      last_request.env["SERVER_NAME"].should == "example.org"
+      expect(last_request.env["SERVER_NAME"]).to eq("example.org")
     end
 
     it "yields the response to a given block" do
       request "/" do |response|
-        response.should be_ok
+        expect(response).to be_ok
       end
     end
 
     it "supports sending :params" do
       request "/", :params => { "foo" => "bar" }
-      last_request.GET["foo"].should == "bar"
+      expect(last_request.GET["foo"]).to eq("bar")
     end
 
     it "doesn't follow redirects by default" do
       request "/redirect"
-      last_response.should be_redirect
-      last_response.body.should be_empty
+      expect(last_response).to be_redirect
+      expect(last_response.body).to be_empty
     end
 
     it "allows passing :input in for POSTs" do
       request "/", :method => :post, :input => "foo"
-      last_request.env["rack.input"].read.should == "foo"
+      expect(last_request.env["rack.input"].read).to eq("foo")
     end
 
     it "converts method names to a uppercase strings" do
       request "/", :method => :put
-      last_request.env["REQUEST_METHOD"].should == "PUT"
+      expect(last_request.env["REQUEST_METHOD"]).to eq("PUT")
     end
 
     it "prepends a slash to the URI path" do
       request "foo"
-      last_request.env["PATH_INFO"].should == "/foo"
+      expect(last_request.env["PATH_INFO"]).to eq("/foo")
     end
 
     it "accepts params and builds query strings for GET requests" do
       request "/foo?baz=2", :params => {:foo => {:bar => "1"}}
-      last_request.GET.should == { "baz" => "2", "foo" => { "bar" => "1" }}
+      expect(last_request.GET).to eq({ "baz" => "2", "foo" => { "bar" => "1" }})
     end
 
     it "parses query strings with repeated variable names correctly" do
       request "/foo?bar=2&bar=3"
-      last_request.GET.should == { "bar" => "3" }
+      expect(last_request.GET).to eq({ "bar" => "3" })
     end
 
     it "accepts raw input in params for GET requests" do
       request "/foo?baz=2", :params => "foo[bar]=1"
-      last_request.GET.should == { "baz" => "2", "foo" => { "bar" => "1" }}
+      expect(last_request.GET).to eq({ "baz" => "2", "foo" => { "bar" => "1" }})
     end
 
     it "does not rewrite a GET query string when :params is not supplied" do
       request "/foo?a=1&b=2&c=3&e=4&d=5+%20"
-      last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5+%20"
+      expect(last_request.query_string).to eq("a=1&b=2&c=3&e=4&d=5+%20")
     end
 
     it "does not overwrite multiple query string keys" do
       request "/foo?a=1&a=2", :params => { :bar => 1 }
-      last_request.query_string.should == "a=1&a=2&bar=1"
+      expect(last_request.query_string).to eq("a=1&a=2&bar=1")
     end
 
     it "accepts params and builds url encoded params for POST requests" do
       request "/foo", :method => :post, :params => {:foo => {:bar => "1"}}
-      last_request.env["rack.input"].read.should == "foo[bar]=1"
+      expect(last_request.env["rack.input"].read).to eq("foo[bar]=1")
     end
 
     it "accepts raw input in params for POST requests" do
       request "/foo", :method => :post, :params => "foo[bar]=1"
-      last_request.env["rack.input"].read.should == "foo[bar]=1"
+      expect(last_request.env["rack.input"].read).to eq("foo[bar]=1")
     end
 
     context "when the response body responds_to?(:close)" do
@@ -160,7 +160,7 @@ describe Rack::Test::Session do
 
       it "closes response's body" do
         body = CloseableBody.new
-        body.should_receive(:close)
+        expect(body).to receive(:close)
 
         app = lambda do |env|
           [200, {"Content-Type" => "text/html", "Content-Length" => "13"}, body]
@@ -177,65 +177,65 @@ describe Rack::Test::Session do
 
         session = Rack::Test::Session.new(Rack::MockSession.new(app))
         session.request("/")
-        session.last_response.body.should == "Hello, World!"
+        expect(session.last_response.body).to eq("Hello, World!")
       end
     end
 
     context "when input is given" do
       it "sends the input" do
         request "/", :method => "POST", :input => "foo"
-        last_request.env["rack.input"].read.should == "foo"
+        expect(last_request.env["rack.input"].read).to eq("foo")
       end
 
       it "does not send a multipart request" do
         request "/", :method => "POST", :input => "foo"
-        last_request.env["CONTENT_TYPE"].should_not == "application/x-www-form-urlencoded"
+        expect(last_request.env["CONTENT_TYPE"]).not_to eq("application/x-www-form-urlencoded")
       end
     end
 
     context "for a POST specified with :method" do
       it "uses application/x-www-form-urlencoded as the CONTENT_TYPE" do
         request "/", :method => "POST"
-        last_request.env["CONTENT_TYPE"].should == "application/x-www-form-urlencoded"
+        expect(last_request.env["CONTENT_TYPE"]).to eq("application/x-www-form-urlencoded")
       end
     end
 
     context "for a POST specified with REQUEST_METHOD" do
       it "uses application/x-www-form-urlencoded as the CONTENT_TYPE" do
         request "/", "REQUEST_METHOD" => "POST"
-        last_request.env["CONTENT_TYPE"].should == "application/x-www-form-urlencoded"
+        expect(last_request.env["CONTENT_TYPE"]).to eq("application/x-www-form-urlencoded")
       end
     end
 
     context "when CONTENT_TYPE is specified in the env" do
       it "does not overwrite the CONTENT_TYPE" do
         request "/", "CONTENT_TYPE" => "application/xml"
-        last_request.env["CONTENT_TYPE"].should == "application/xml"
+        expect(last_request.env["CONTENT_TYPE"]).to eq("application/xml")
       end
     end
 
     context "when the URL is https://" do
       it "sets rack.url_scheme to https" do
         get "https://example.org/"
-        last_request.env["rack.url_scheme"].should == "https"
+        expect(last_request.env["rack.url_scheme"]).to eq("https")
       end
 
       it "sets SERVER_PORT to 443" do
         get "https://example.org/"
-        last_request.env["SERVER_PORT"].should == "443"
+        expect(last_request.env["SERVER_PORT"]).to eq("443")
       end
 
       it "sets HTTPS to on" do
         get "https://example.org/"
-        last_request.env["HTTPS"].should == "on"
+        expect(last_request.env["HTTPS"]).to eq("on")
       end
     end
 
     context "for a XHR" do
       it "sends XMLHttpRequest for the X-Requested-With header" do
         request "/", :xhr => true
-        last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
-        last_request.should be_xhr
+        expect(last_request.env["HTTP_X_REQUESTED_WITH"]).to eq("XMLHttpRequest")
+        expect(last_request).to be_xhr
       end
     end
   end
@@ -245,21 +245,21 @@ describe Rack::Test::Session do
       header "User-Agent", "Firefox"
       request "/"
 
-      last_request.env["HTTP_USER_AGENT"].should == "Firefox"
+      expect(last_request.env["HTTP_USER_AGENT"]).to eq("Firefox")
     end
 
     it "sets a Content-Type to be sent with requests" do
       header "Content-Type", "application/json"
       request "/"
 
-      last_request.env["CONTENT_TYPE"].should == "application/json"
+      expect(last_request.env["CONTENT_TYPE"]).to eq("application/json")
     end
 
     it "sets a Host to be sent with requests" do
       header "Host", "www.example.ua"
       request "/"
 
-      last_request.env["HTTP_HOST"].should == "www.example.ua"
+      expect(last_request.env["HTTP_HOST"]).to eq("www.example.ua")
     end
 
     it "persists across multiple requests" do
@@ -267,7 +267,7 @@ describe Rack::Test::Session do
       request "/"
       request "/"
 
-      last_request.env["HTTP_USER_AGENT"].should == "Firefox"
+      expect(last_request.env["HTTP_USER_AGENT"]).to eq("Firefox")
     end
 
     it "overwrites previously set headers" do
@@ -275,7 +275,7 @@ describe Rack::Test::Session do
       header "User-Agent", "Safari"
       request "/"
 
-      last_request.env["HTTP_USER_AGENT"].should == "Safari"
+      expect(last_request.env["HTTP_USER_AGENT"]).to eq("Safari")
     end
 
     it "can be used to clear a header" do
@@ -283,14 +283,14 @@ describe Rack::Test::Session do
       header "User-Agent", nil
       request "/"
 
-      last_request.env.should_not have_key("HTTP_USER_AGENT")
+      expect(last_request.env).not_to have_key("HTTP_USER_AGENT")
     end
 
     it "is overridden by headers sent during the request" do
       header "User-Agent", "Firefox"
       request "/", "HTTP_USER_AGENT" => "Safari"
 
-      last_request.env["HTTP_USER_AGENT"].should == "Safari"
+      expect(last_request.env["HTTP_USER_AGENT"]).to eq("Safari")
     end
   end
 
@@ -299,7 +299,7 @@ describe Rack::Test::Session do
       env "rack.session", {:csrf => 'token'}
       request "/"
 
-      last_request.env["rack.session"].should == {:csrf => 'token'}
+      expect(last_request.env["rack.session"]).to eq({:csrf => 'token'})
     end
 
     it "persists across multiple requests" do
@@ -307,7 +307,7 @@ describe Rack::Test::Session do
       request "/"
       request "/"
 
-      last_request.env["rack.session"].should == {:csrf => 'token'}
+      expect(last_request.env["rack.session"]).to eq({:csrf => 'token'})
     end
 
     it "overwrites previously set envs" do
@@ -315,7 +315,7 @@ describe Rack::Test::Session do
       env "rack.session", {:some => :thing}
       request "/"
 
-      last_request.env["rack.session"].should == {:some => :thing}
+      expect(last_request.env["rack.session"]).to eq({:some => :thing})
     end
 
     it "can be used to clear a env" do
@@ -323,14 +323,14 @@ describe Rack::Test::Session do
       env "rack.session", nil
       request "/"
 
-      last_request.env.should_not have_key("X_CSRF_TOKEN")
+      expect(last_request.env).not_to have_key("X_CSRF_TOKEN")
     end
 
     it "is overridden by envs sent during the request" do
       env "rack.session", {:csrf => 'token'}
       request "/", "rack.session" => {:some => :thing}
 
-      last_request.env["rack.session"].should == {:some => :thing}
+      expect(last_request.env["rack.session"]).to eq({:some => :thing})
     end
   end
 
@@ -339,7 +339,7 @@ describe Rack::Test::Session do
       authorize "bryan", "secret"
       request "/"
 
-      last_request.env["HTTP_AUTHORIZATION"].should == "Basic YnJ5YW46c2VjcmV0\n"
+      expect(last_request.env["HTTP_AUTHORIZATION"]).to eq("Basic YnJ5YW46c2VjcmV0\n")
     end
 
     it "includes the header for subsequent requests" do
@@ -347,7 +347,7 @@ describe Rack::Test::Session do
       request "/"
       request "/"
 
-      last_request.env["HTTP_AUTHORIZATION"].should == "Basic YnJ5YW46c2VjcmV0\n"
+      expect(last_request.env["HTTP_AUTHORIZATION"]).to eq("Basic YnJ5YW46c2VjcmV0\n")
     end
   end
 
@@ -356,56 +356,56 @@ describe Rack::Test::Session do
       get "/redirect"
       follow_redirect!
 
-      last_response.should_not be_redirect
-      last_response.body.should == "You've been redirected"
-      last_request.env["HTTP_REFERER"].should eql("http://example.org/redirect")
+      expect(last_response).not_to be_redirect
+      expect(last_response.body).to eq("You've been redirected")
+      expect(last_request.env["HTTP_REFERER"]).to eql("http://example.org/redirect")
     end
 
     it "does not include params when following the redirect" do
       get "/redirect", { "foo" => "bar" }
       follow_redirect!
 
-      last_request.GET.should == {}
+      expect(last_request.GET).to eq({})
     end
 
     it "raises an error if the last_response is not set" do
-      lambda {
+      expect {
         follow_redirect!
-      }.should raise_error(Rack::Test::Error)
+      }.to raise_error(Rack::Test::Error)
     end
 
     it "raises an error if the last_response is not a redirect" do
       get "/"
 
-      lambda {
+      expect {
         follow_redirect!
-      }.should raise_error(Rack::Test::Error)
+      }.to raise_error(Rack::Test::Error)
     end
   end
 
   describe "#last_request" do
     it "returns the most recent request" do
       request "/"
-      last_request.env["PATH_INFO"].should == "/"
+      expect(last_request.env["PATH_INFO"]).to eq("/")
     end
 
     it "raises an error if no requests have been issued" do
-      lambda {
+      expect {
         last_request
-      }.should raise_error(Rack::Test::Error)
+      }.to raise_error(Rack::Test::Error)
     end
   end
 
   describe "#last_response" do
     it "returns the most recent response" do
       request "/"
-      last_response["Content-Type"].should == "text/html;charset=utf-8"
+      expect(last_response["Content-Type"]).to eq("text/html;charset=utf-8")
     end
 
-    it "raises an error if no requests have been issued" do
-      lambda {
+    it "raises an error if no requests have been issued",focus: true do
+      expect {
         last_response
-      }.should raise_error
+      }.to raise_error(Rack::Test::Error)
     end
   end
 
@@ -418,7 +418,7 @@ describe Rack::Test::Session do
       end
 
       get "/"
-      ran.should == true
+      expect(ran).to eq(true)
     end
 
     it "runs multiple callbacks" do
@@ -431,7 +431,7 @@ describe Rack::Test::Session do
       end
 
       get "/"
-      count.should == 2
+      expect(count).to eq(2)
     end
   end
 
@@ -444,27 +444,27 @@ describe Rack::Test::Session do
 
     it "uses the provided params hash" do
       get "/", :foo => "bar"
-      last_request.GET.should == { "foo" => "bar" }
+      expect(last_request.GET).to eq({ "foo" => "bar" })
     end
 
     it "sends params with parens in names" do
       get "/", "foo(1i)" => "bar"
-      last_request.GET["foo(1i)"].should == "bar"
+      expect(last_request.GET["foo(1i)"]).to eq("bar")
     end
 
     it "supports params with encoding sensitive names" do
       get "/", "foo bar" => "baz"
-      last_request.GET["foo bar"].should == "baz"
+      expect(last_request.GET["foo bar"]).to eq("baz")
     end
 
     it "supports params with nested encoding sensitive names" do
       get "/", "boo" => {"foo bar" => "baz"}
-      last_request.GET.should == {"boo" => {"foo bar" => "baz"}}
+      expect(last_request.GET).to eq({"boo" => {"foo bar" => "baz"}})
     end
 
     it "accepts params in the path" do
       get "/?foo=bar"
-      last_request.GET.should == { "foo" => "bar" }
+      expect(last_request.GET).to eq({ "foo" => "bar" })
     end
   end
 
@@ -485,28 +485,28 @@ describe Rack::Test::Session do
 
     it "uses the provided params hash" do
       post "/", :foo => "bar"
-      last_request.POST.should == { "foo" => "bar" }
+      expect(last_request.POST).to eq({ "foo" => "bar" })
     end
 
     it "supports params with encoding sensitive names" do
       post "/", "foo bar" => "baz"
-      last_request.POST["foo bar"].should == "baz"
+      expect(last_request.POST["foo bar"]).to eq("baz")
     end
 
     it "uses application/x-www-form-urlencoded as the CONTENT_TYPE" do
       post "/"
-      last_request.env["CONTENT_TYPE"].should == "application/x-www-form-urlencoded"
+      expect(last_request.env["CONTENT_TYPE"]).to eq("application/x-www-form-urlencoded")
     end
 
     it "accepts a body" do
       post "/", "Lobsterlicious!"
-      last_request.body.read.should == "Lobsterlicious!"
+      expect(last_request.body.read).to eq("Lobsterlicious!")
     end
 
     context "when CONTENT_TYPE is specified in the env" do
       it "does not overwrite the CONTENT_TYPE" do
         post "/", {}, { "CONTENT_TYPE" => "application/xml" }
-        last_request.env["CONTENT_TYPE"].should == "application/xml"
+        expect(last_request.env["CONTENT_TYPE"]).to eq("application/xml")
       end
     end
   end
@@ -520,7 +520,7 @@ describe Rack::Test::Session do
 
     it "accepts a body" do
       put "/", "Lobsterlicious!"
-      last_request.body.read.should == "Lobsterlicious!"
+      expect(last_request.body.read).to eq("Lobsterlicious!")
     end
   end
 
@@ -533,7 +533,7 @@ describe Rack::Test::Session do
 
     it "accepts a body" do
       patch "/", "Lobsterlicious!"
-      last_request.body.read.should == "Lobsterlicious!"
+      expect(last_request.body.read).to eq("Lobsterlicious!")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,41 +29,41 @@ shared_examples_for "any #verb methods" do
   it "requests the URL using VERB" do
     send(verb, "/")
 
-    check last_request.env["REQUEST_METHOD"].should == verb.upcase
-    last_response.should be_ok
+    check expect(last_request.env["REQUEST_METHOD"]).to eq(verb.upcase)
+    expect(last_response).to be_ok
   end
 
   it "uses the provided env" do
     send(verb, "/", {}, { "HTTP_USER_AGENT" => "Rack::Test" })
-    last_request.env["HTTP_USER_AGENT"].should == "Rack::Test"
+    expect(last_request.env["HTTP_USER_AGENT"]).to eq("Rack::Test")
   end
 
   it "yields the response to a given block" do
     yielded = false
 
     send(verb, "/") do |response|
-      response.should be_ok
+      expect(response).to be_ok
       yielded = true
     end
 
-    yielded.should be_true
+    expect(yielded).to be_truthy
   end
 
   it "sets the HTTP_HOST header with port" do
     send(verb, "http://example.org:8080/uri")
-    last_request.env["HTTP_HOST"].should == "example.org:8080"
+    expect(last_request.env["HTTP_HOST"]).to eq("example.org:8080")
   end
 
   it "sets the HTTP_HOST header without port" do
     send(verb, "/uri")
-    last_request.env["HTTP_HOST"].should == "example.org"
+    expect(last_request.env["HTTP_HOST"]).to eq("example.org")
   end
 
   context "for a XHR" do
     it "sends XMLHttpRequest for the X-Requested-With header" do
       send(verb, "/", {}, { :xhr => true })
-      last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
-      last_request.should be_xhr
+      expect(last_request.env["HTTP_X_REQUESTED_WITH"]).to eq("XMLHttpRequest")
+      expect(last_request).to be_xhr
     end
   end
 end

--- a/spec/support/matchers/body.rb
+++ b/spec/support/matchers/body.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_body do |expected|
   match do |response|
-    response.body.should == expected
+    expect(response.body).to eq(expected)
   end
 
   description do


### PR DESCRIPTION
In order to make it easier to merge other pull requests,
we should update to rspec 3.
This PR updats the Gemfile.lock to use rspec 3.4, it also
updats the test syntax to match the new rspec testing style.

This Change has been ported from
[this contribution](https://github.com/brynary/rack-test/pull/134/commits)