### PR TITLE
Make `build_multipart` work without mixing in Rack::Test::Utils

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -3,6 +3,7 @@ module Rack
 
     module Utils # :nodoc:
       include Rack::Utils
+      extend Rack::Utils
 
       def build_nested_query(value, prefix = nil)
         case value
@@ -83,13 +84,13 @@ module Rack
           flattened_params
         end
       end
-
       module_function :build_multipart
 
     private
       def build_parts(parameters)
         get_parts(parameters).join + "--#{MULTIPART_BOUNDARY}--\r"
       end
+      module_function :build_parts
 
       def get_parts(parameters)
         parameters.map { |name, value|
@@ -115,6 +116,7 @@ module Rack
           end
         }
       end
+      module_function :get_parts
 
       def build_primitive_part(parameter_name, value)
         unless value.is_a? Array
@@ -129,6 +131,7 @@ Content-Disposition: form-data; name="#{parameter_name}"\r
 EOF
         end.join
       end
+      module_function :build_primitive_part
 
       def build_file_part(parameter_name, uploaded_file)
         ::File.open(uploaded_file.path, "rb") do |physical_file|
@@ -143,6 +146,7 @@ Content-Length: #{::File.stat(uploaded_file.path).size}\r
 EOF
         end
       end
+      module_function :build_file_part
 
     end
 

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -50,10 +50,10 @@ describe Rack::Test::Utils do
     end
   end
 
-  describe "build_multipart" do
+  describe "Rack::Test::Utils.build_multipart" do
     it "builds multipart bodies" do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("submit-name" => "Larry", "files" => files)
+      data  = Rack::Test::Utils.build_multipart("submit-name" => "Larry", "files" => files)
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -69,7 +69,7 @@ describe Rack::Test::Utils do
 
    it "builds multipart bodies from array of files" do
       files = [Rack::Test::UploadedFile.new(multipart_file("foo.txt")), Rack::Test::UploadedFile.new(multipart_file("bar.txt"))]
-      data  = build_multipart("submit-name" => "Larry", "files" => files)
+      data  = Rack::Test::Utils.build_multipart("submit-name" => "Larry", "files" => files)
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -89,7 +89,7 @@ describe Rack::Test::Utils do
 
     it "builds nested multipart bodies" do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("people" => [{"submit-name" => "Larry", "files" => files}], "foo" => ['1', '2'])
+      data  = Rack::Test::Utils.build_multipart("people" => [{"submit-name" => "Larry", "files" => files}], "foo" => ['1', '2'])
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -106,7 +106,7 @@ describe Rack::Test::Utils do
 
     it "builds nested multipart bodies with an array of hashes" do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("files" => files, "foo" => [{"id" => "1", "name" => 'Dave'}, {"id" => "2", "name" => 'Steve'}])
+      data  = Rack::Test::Utils.build_multipart("files" => files, "foo" => [{"id" => "1", "name" => 'Dave'}, {"id" => "2", "name" => 'Steve'}])
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -122,7 +122,7 @@ describe Rack::Test::Utils do
 
     it "builds nested multipart bodies with arbitrarily nested array of hashes" do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("files" => files, "foo" => {"bar" => [{"id" => "1", "name" => 'Dave'},
+      data  = Rack::Test::Utils.build_multipart("files" => files, "foo" => {"bar" => [{"id" => "1", "name" => 'Dave'},
                                                                     {"id" => "2", "name" => 'Steve', "qux" => [{"id" => '3', "name" => 'mike'},
                                                                                                                {"id" => '4', "name" => 'Joan'}]}]})
 
@@ -142,7 +142,7 @@ describe Rack::Test::Utils do
 
     it 'does not break with params that look nested, but are not' do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("foo[]" => "1", "bar[]" => {"qux" => "2"}, "files[]" => files)
+      data  = Rack::Test::Utils.build_multipart("foo[]" => "1", "bar[]" => {"qux" => "2"}, "files[]" => files)
 
       options = {
         "CONTENT_TYPE" => "multipart/form-data; boundary=#{Rack::Test::MULTIPART_BOUNDARY}",
@@ -159,7 +159,7 @@ describe Rack::Test::Utils do
 
     it 'allows for nested files' do
       files = Rack::Test::UploadedFile.new(multipart_file("foo.txt"))
-      data  = build_multipart("foo" => [{"id" => "1", "data" => files},
+      data  = Rack::Test::Utils.build_multipart("foo" => [{"id" => "1", "data" => files},
                                         {"id" => "2", "data" => ["3", "4"]}])
 
       options = {
@@ -176,13 +176,13 @@ describe Rack::Test::Utils do
     end
 
     it "returns nil if no UploadedFiles were used" do
-      data = build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
+      data = Rack::Test::Utils.build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
       expect(data).to be_nil
     end
 
     it "raises ArgumentErrors if params is not a Hash" do
       expect {
-        build_multipart("foo=bar")
+        Rack::Test::Utils.build_multipart("foo=bar")
       }.to raise_error(ArgumentError, "value must be a Hash")
     end
 


### PR DESCRIPTION
expose Rack::Test::Utils methods as module functions to avoid
a mixing requirement of utility functions.

Implements PR #131. Thanks to @tenderlove for implementing this
feature.